### PR TITLE
ci: remove changelog job from all-green check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
   all-green:
     name: All checks passed
     if: always()
-    needs: [test, check, changelog]
+    needs: [test, check]
     runs-on: ubuntu-latest
     steps:
       - name: Require all successes

--- a/changelog.d/34.changed.md
+++ b/changelog.d/34.changed.md
@@ -1,0 +1,1 @@
+- Removed `changelog` job from the `all-green` workflow check to avoid pipeline failures when changelog updates are skipped.


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Provide a clear and concise description of what this PR does -->
This pull request updates the GitHub Actions workflow by removing the changelog job from the all-green required checks. This prevents the entire workflow from failing when the changelog job is skipped, improving pipeline stability.

## Breaking Changes

- [ ] This PR introduces breaking changes

<!-- If yes, describe what breaks and migration steps -->

## Changelog Entry

- [x] Added changelog fragment in `changelog.d/` directory
- [ ] No changelog entry needed (non-changelog category)

## Testing & Quality

- [x] All tests pass locally (`nox -s tests`)
- [x] Linting and Type checking passes (`nox -s check`)
- [ ] Added tests for new functionality
- [ ] Updated documentation if needed
- [ ] Tested manually (if applicable)

## Review Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Added appropriate labels
- [ ] Linked related issues (closes #123)
- [x] PR title follows conventional commits format
- [x] All CI checks are passing

## Additional Context

<!-- Any additional information, screenshots, or context about the PR -->
