### PR TITLE
fix: fix dependabot grouping the PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
@@ -7,11 +8,16 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "no-changelog"
     commit-message:
       prefix: "deps"
+      include: "scope"
     versioning-strategy: auto
     rebase-strategy: auto
 
@@ -22,10 +28,15 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "ci"
       - "no-changelog"
     commit-message:
       prefix: "ci"
+      include: "scope"
     rebase-strategy: auto


### PR DESCRIPTION
# Pull Request

## Summary

Fix dependabot grouping the dependency update and create single PR

## Breaking Changes

- [ ] This PR introduces breaking changes

<!-- If yes, describe what breaks and migration steps -->

## Changelog Entry

- [ ] Added changelog fragment in `changelog.d/` directory
- [x] No changelog entry needed (non-changelog category)

## Testing & Quality

- [x] All tests pass locally (`nox -s tests`)
- [x] Linting and Type checking passes (`nox -s check`)
- [ ] Added tests for new functionality
- [ ] Updated documentation if needed
- [ ] Tested manually (if applicable)

## Review Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Added appropriate labels
- [ ] Linked related issues (closes #123)
- [x] PR title follows conventional commits format
- [x] All CI checks are passing

## Additional Context

<!-- Any additional information, screenshots, or context about the PR -->
